### PR TITLE
Added riderct to /guacamole/ in the Caddyfile

### DIFF
--- a/user-data.yml
+++ b/user-data.yml
@@ -160,6 +160,7 @@ write_files:
   - path: /home/{{ default_user }}/configs/caddy/Caddyfile
     content: |
       {{ fqdn }} {
+          redir / /guacamole/ 308
           reverse_proxy guacamole:8080 {
               trusted_proxies private_ranges
               flush_interval -1


### PR DESCRIPTION
I added a redirect from "/" to "/guacamole/" in the Caddyfile. This seems useful to me but feel free to reject if it was not there for a reason.